### PR TITLE
fix: CI and CD workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,8 +24,10 @@ jobs:
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag moneydetector.azurecr.io/server:${{github.run_number}}
       
-    - name: Adds metadata to the image    
-      run: docker label "commit=${{ GITHUB_SHA }}"
+    - name: Adds metadata to the image
+      env:
+        sha: ${{ GITHUB_SHA }}
+      run: docker label "commit=$sha"
       
     
     - name: Push to private registry

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,17 +19,14 @@ jobs:
       # You may pin to the exact commit or the version.
       env: 
         pass: ${{ secrets.REGISTRY_PASSWORD }}
+        
       run: echo $pass | docker login moneydetector.azurecr.io -u moneydetector --password-stdin
     
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag moneydetector.azurecr.io/server:${{github.run_number}}
-      
-    - name: Adds metadata to the image
-      env:
+      env: 
         sha: ${{ github.GITHUB_SHA }}
-      run: docker label "commit=$sha"
+      run: docker build . --label "commit=$sha" --file Dockerfile --tag moneydetector.azurecr.io/server:${{github.run_number}}
       
-    
     - name: Push to private registry
       env: 
         pass: ${{ secrets.RegistryPassword }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,7 +22,11 @@ jobs:
       run: echo $pass | docker login moneydetector.azurecr.io -u moneydetector --password-stdin
     
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag moneydetector.azurecr.io/server:1.0.1:${{github.run_number}}
+      run: docker build . --file Dockerfile --tag moneydetector.azurecr.io/server:${{github.run_number}}
+      
+    - name: Adds metadata to the image    
+      run: docker label "commit=${{ GITHUB_SHA }}"
+      
     
     - name: Push to private registry
       env: 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,20 +15,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     
-    - name: Docker Login
-      # You may pin to the exact commit or the version.      
-      uses: docker/login-action@v2.1.0
-      with:
-        # Server address of Docker registry. If not set then will default to Docker Hub
-        registry: moneydetector.azurecr.io
-        # Username used to log against the Docker registry
-        username: moneydetector
-        # Password or personal access token used to log against the Docker registry
-        password: $pass        
-        # Log out from the Docker registry at the end of a job
-        logout: true     
+    - name: Registry Login
+      # You may pin to the exact commit or the version.
       env: 
         pass: ${{ secrets.REGISTRY_PASSWORD }}
+      run: echo $pass | docker login moneydetector.azurecr.io -u moneydetector --password-stdin
     
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag moneydetector.azurecr.io/server:1.0.1:$($current_date)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,9 +22,9 @@ jobs:
       run: echo $pass | docker login moneydetector.azurecr.io -u moneydetector --password-stdin
     
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag moneydetector.azurecr.io/server:1.0.1:$($current_date)
+      run: docker build . --file Dockerfile --tag moneydetector.azurecr.io/server:1.0.1:${{github.run_number}}
     
     - name: Push to private registry
       env: 
         pass: ${{ secrets.RegistryPassword }}
-      run: docker push moneydetector.azurecr.io/server:1.0.1:$($current_date)
+      run: docker push moneydetector.azurecr.io/server:1.0.1:${{github.run_number}}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,4 +30,4 @@ jobs:
     - name: Push to private registry
       env: 
         pass: ${{ secrets.RegistryPassword }}
-      run: docker push moneydetector.azurecr.io/server:1.0.1:${{github.run_number}}
+      run: docker push moneydetector.azurecr.io/server:${{github.run_number}}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,7 +26,7 @@ jobs:
       
     - name: Adds metadata to the image
       env:
-        sha: ${{ GITHUB_SHA }}
+        sha: ${{ env.GITHUB_SHA }}
       run: docker label "commit=$sha"
       
     

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,7 +26,7 @@ jobs:
       
     - name: Adds metadata to the image
       env:
-        sha: ${{ env.GITHUB_SHA }}
+        sha: ${{ github.GITHUB_SHA }}
       run: docker label "commit=$sha"
       
     


### PR DESCRIPTION
Fixes the CI and CD workflow. 
Will publish images directly to the default Container Registry (ACR).
Images are versioned through build number only (no semver, since this isn't a library) and are labelled with the commit sha.